### PR TITLE
Implements file copy and removal in local build process

### DIFF
--- a/src/pages/edit.vue
+++ b/src/pages/edit.vue
@@ -385,7 +385,11 @@
                         @click="savePathHandle('open')"
                     >
                         <template #append>
-                            <el-tooltip class="box-item" placement="bottom">
+                            <el-tooltip
+                                class="box-item"
+                                placement="bottom"
+                                :content="t('savePath')"
+                            >
                                 <el-button
                                     class="distUpload"
                                     :icon="FolderOpened"
@@ -529,8 +533,8 @@ import {
     exists,
     remove,
     writeFile,
-    rename,
     mkdir,
+    copyFile,
 } from '@tauri-apps/plugin-fs'
 import {
     appCacheDir,
@@ -1646,7 +1650,8 @@ const easyLocal = async () => {
                     targetName,
                     `${store.currentProject.showName}.exe`
                 )
-                await rename(targetExe, chinaExeName)
+                await copyFile(targetExe, chinaExeName)
+                await remove(targetExe)
             }
             oneMessage.success(t('localSuccess'))
             buildLoading.value = false


### PR DESCRIPTION
Replaces the rename operation with a copy followed by removal of the original file during the local build process.

This change ensures the original file remains intact until the copy is confirmed, improving reliability in file management.

Updates tooltip content for better user guidance in the save path functionality.