### PR TITLE
Replaces command replacement with file copy operation

### DIFF
--- a/src/pages/edit.vue
+++ b/src/pages/edit.vue
@@ -1613,7 +1613,7 @@ const easyLocal = async () => {
             await writeFile(icoPath, icoBlob)
             rhtarget = rhtarget.replace('app.ico', icoPath)
         } else {
-            rhtarget = rhtarget.split('[COMMANDS]')[0]
+            await copyFile(ppexePath, targetExe)
         }
         const rhscriptPath = await join(appDataDirPath, 'rhscript.txt')
         await writeTextFile(rhscriptPath, rhtarget)


### PR DESCRIPTION
Modifies the code to replace the logic for handling the `rhtarget` variable.

Instead of splitting the string at '[COMMANDS]', it now copies a file from `ppexePath` to `targetExe`.

This change aims to streamline the process and ensure the correct file is managed for the application.