### PR TITLE
fix: conditionally initialize gtag

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,9 @@ const pinia = createPinia()
 app.use(pinia)
 app.use(router)
 app.use(i18n)
-createGtag({
-    tagId: import.meta.env.VITE_GTAG_ID,
-})
+if (import.meta.env.VITE_GTAG_ID) {
+    createGtag({
+        tagId: import.meta.env.VITE_GTAG_ID,
+    });
+}
 app.mount('#app')


### PR DESCRIPTION
This pull request resolves a potential issue where the Google Analytics integration (vue-gtag) is initialized without first checking if the necessary environment variable (VITE_GTAG_ID) is present. Problem The application was unconditionally calling createGtag with import.meta.env.VITE_GTAG_ID. If this variable is not defined in the build environment, it could lead to runtime errors or cause the analytics feature to fail silently. Solution I've wrapped the createGtag function call inside a conditional block. This ensures that Google Analytics is only initialized if a valid VITE_GTAG_ID has been provided in the environment configuration. This change makes the application more robust and prevents errors in development or deployment environments where analytics tracking might not be configured.